### PR TITLE
allow additional metadata field in artifact

### DIFF
--- a/chainmeta/config/categories.json
+++ b/chainmeta/config/categories.json
@@ -367,7 +367,8 @@
     {
         "key": "sanctioned",
         "display_name": "Sanctioned",
-        "description": "Addresses that have been sanctioned by some governments in the world."
+        "description": "Addresses that have been sanctioned by some governments in the world.",
+        "additional_metadata_fields": ["valid_from", "valid_to", "reason"]
     },
     {
         "key": "phishing",

--- a/chainmeta/contrib/chaintool.py
+++ b/chainmeta/contrib/chaintool.py
@@ -87,6 +87,7 @@ class ChaintoolTranslator(ITranslator):
             source=ChaintoolTranslator.normalize_not_none_key(raw_metadata["source"]),
             submitted_by=raw_metadata["submitted_by"],
             submitted_on=raw_metadata["tagged_on"],
+            additional_metadata={},
         )
 
     def from_common_schema(

--- a/chainmeta/contrib/messari.py
+++ b/chainmeta/contrib/messari.py
@@ -32,7 +32,7 @@ class MessariTranslator(ITranslator):
 class MessariValidator(IValidator):
     def validate(self, metadata: object):
         # Add your implementation here
-        return True
+        return
 
 
 schema_path = "_schema.json"

--- a/chainmeta/db.py
+++ b/chainmeta/db.py
@@ -147,6 +147,7 @@ def reduce(record_list: List[ChainmetaRecord]) -> List[ChainmetaItem]:
             source=group[0].source,
             submitted_by=group[0].submitted_by,
             submitted_on=str(group[0].submitted_on),
+            additional_metadata={},
         )
 
         for record in group:

--- a/chainmeta/db.py
+++ b/chainmeta/db.py
@@ -81,7 +81,7 @@ def flatten(metadata_list: List[ChainmetaItem]) -> List[ChainmetaRecord]:
     Function flatten() translates chain metadata in common schema to database records.
     """
 
-    flattened_records: List[ChainmetaRecord | None] = []
+    flattened_records: List[Optional[ChainmetaRecord]] = []
     for metadata in metadata_list:
         address, network, source, submitted_by = (
             metadata.address,

--- a/chainmeta/metadata.py
+++ b/chainmeta/metadata.py
@@ -46,6 +46,9 @@ class ChainmetaItem:
     # Last updated time
     submitted_on: str
 
+    # Additional metadata
+    additional_metadata: dict
+
 
 class ITranslator(ABC):
     def to_common_schema(self, raw_metadata) -> Optional[ChainmetaItem]:
@@ -59,6 +62,8 @@ class ITranslator(ABC):
 
 class Translator(ITranslator):
     def to_common_schema(self, raw_metadata) -> Optional[ChainmetaItem]:
+        if "additional_metadata" not in raw_metadata:
+            raw_metadata["additional_metadata"] = {}
         return ChainmetaItem(**raw_metadata)
 
     def from_common_schema(

--- a/chainmeta/schema/__init__.py
+++ b/chainmeta/schema/__init__.py
@@ -58,6 +58,14 @@ register(
     "https://github.com/openchainmeta/chainmetareader/chainmeta/schema/artifact_schema.json",  # noqa: E501
     common_schema,
 )
+register(
+    "https://github.com/microscopexyz/chainmeta-core/chainmeta/schemas/artifact_schema.json",  # noqa: E501
+    common_schema,
+)
+register(
+    "https://github.com/microscopexyz/chainmeta-core/chainmeta/schema/artifact_schema.json",  # noqa: E501
+    common_schema,
+)
 
 
 for f in os.listdir(Path(__file__).parent.parent.resolve().joinpath(ContribFolder)):

--- a/chainmeta/schema/artifact_schema.json
+++ b/chainmeta/schema/artifact_schema.json
@@ -10,6 +10,8 @@
             "chain",
             "address",
             "categories",
+            "entity",
+            "name",
             "source",
             "submitted_by",
             "submitted_on"
@@ -22,17 +24,10 @@
                 "$ref": "/schemas/address"
             },
             "entity": {
-                "anyOf": [
-                    {
-                        "nullable": true
-                    },
-                    {
-                        "$ref": "/schemas/entity"
-                    }
-                ]
+                "$ref": "/schemas/entity"
             },
             "name": {
-                "type": ["string", "null"]
+                "$ref": "/schemas/name"
             },
             "categories": {
                 "type": "array",
@@ -49,6 +44,41 @@
             "submitted_on": {
                 "type": "string",
                 "format": "date"
+            },
+            "additional_metadata": {
+                "type": "object",
+                "properties": {
+                    "valid_from": {
+                        "type": "string",
+                        "anyOf": [
+                            {
+                                "format": "date"
+                            },
+                            {
+                                "format": "date-time"
+                            }
+                        ]
+                    },
+                    "valid_to": {
+                        "type": "string",
+                        "anyOf": [
+                            {
+                                "format": "date"
+                            },
+                            {
+                                "format": "date-time"
+                            }
+                        ]
+                    },
+                    "reason": {
+                        "type": "string",
+                        "format": "uri"
+
+                    }
+                }
+            },
+            "deleted": {
+                "type": "boolean"
             }
         },
         "additionalProperties": false
@@ -56,7 +86,7 @@
     "$defs": {
         "chain": {
             "$id": "/schemas/chain",
-            "type": "chain"
+            "type": "string"
         },
         "address": {
             "$id": "/schemas/address",
@@ -64,15 +94,29 @@
         },
         "entity": {
             "$id": "/schemas/entity",
-            "type": "entity"
+            "type": [
+                "string",
+                "null"
+            ]
         },
         "category": {
             "$id": "/schemas/category",
-            "type": "category"
+            "type": "string"
+        },
+        "name": {
+            "$id": "/schemas/name",
+            "type": [
+                "string",
+                "null"
+            ]
         },
         "source": {
             "$id": "/schemas/source",
-            "type": "source"
+            "type": "string"
+        },
+        "additional_metadata": {
+            "$id": "/schemas/additional_metadata",
+            "type": "object"
         }
     }
 }

--- a/tests/data/artifacts/coinbase_artifact_additional_sample.json
+++ b/tests/data/artifacts/coinbase_artifact_additional_sample.json
@@ -1,0 +1,84 @@
+[
+    {
+        "address": "0xf177aa7b0602f787f6f01c65f4b2e267336fd349",
+        "chain": "ethereum_mainnet",
+        "entity": "uniswap",
+        "name": "Uniswap V2: Hmf",
+        "categories": [
+            "defi",
+            "dex"
+        ],
+        "source": "ground_truth",
+        "submitted_by": "coinbase",
+        "submitted_on": "2022-09-21 00:00:00"
+    },
+    {
+        "address": "0xd62f1beba129440c5c07e4fb597ec1f61260d26b",
+        "chain": "ethereum_mainnet",
+        "entity": "uniswap",
+        "name": "Uniswap V2: $Ashiba",
+        "categories": [
+            "defi",
+            "dex"
+        ],
+        "source": "ground_truth",
+        "submitted_by": "coinbase",
+        "submitted_on": "2022-09-21 00:00:00"
+    },
+    {
+        "address": "0x0db4078fa4fc916fc2b881aca99039ccdde6fa46",
+        "chain": "ethereum_mainnet",
+        "entity": "binance",
+        "name": "Binance",
+        "categories": [
+            "exchange",
+            "no_kyc"
+        ],
+        "source": "ground_truth",
+        "submitted_by": "coinbase",
+        "submitted_on": "2022-12-17 00:00:00.000000000"
+    },
+    {
+        "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
+        "chain": "ethereum_mainnet",
+        "entity": "ren",
+        "name": "Ren: Renzec Token",
+        "categories": [
+            "bridging",
+            "dapp"
+        ],
+        "source": "ground_truth",
+        "submitted_by": "coinbase",
+        "submitted_on": "2022-09-21 00:00:00.000000000"
+    },
+    {
+        "address": "0xd5da8cef79c430d337fdb4d7a5b6646132395a86",
+        "chain": "ethereum_mainnet",
+        "entity": "balancer",
+        "name": "Balancer: Safe2/Eth/Cover/Dai/10/40/10",
+        "categories": [
+            "defi",
+            "dex"
+        ],
+        "source": "ground_truth",
+        "submitted_by": "coinbase",
+        "submitted_on": "2022-09-21 00:00:00.000000000"
+    },
+    {
+        "address": "0xd5da8cef79c430d337fdb4d7a5b6646132395a86",
+        "chain": "ethereum_mainnet",
+        "entity": null,
+        "name": null,
+        "categories": [
+            "sanctioned"
+        ],
+        "source": "ground_truth",
+        "submitted_by": "coinbase",
+        "submitted_on": "2022-09-21 00:00:00.000000000",
+        "additional_metadata": {
+            "valid_from": "2022-09-21 00:00:00.000000000",
+            "valid_to": "2024-09-21 00:00:00.000000000",
+            "reason": "https://xyz.com"
+        }
+    }
+]

--- a/tests/data/coinbase_additional_metadata_sample.json
+++ b/tests/data/coinbase_additional_metadata_sample.json
@@ -1,0 +1,22 @@
+{
+    "community": "openchainmeta",
+    "provider": {
+        "provider_name": "coinbase",
+        "provider_id": "ocm000002",
+        "provider_signature": ""
+    },
+    "version": "v1",
+    "revision": 1,
+    "introduction": "https://github.com/openchainmeta/chainmetareader/doc/coinbase/introduction.md",
+    "chainmetadata": {
+        "schema": "https://github.com/openchainmeta/chainmetareader/chainmeta/schemas/artifact_schema.json",
+        "artifact": [
+            {
+                "artifact_type": "local file",
+                "path": "file:///artifacts/coinbase_artifact_additional_sample.json",
+                "fileformat": "json",
+                "signature": "0fdae0be76072b2c98a098d0b2df8079"
+            }
+        ]
+    }
+}

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -26,6 +26,7 @@ import chainmeta
         ("chaintool_sample.json", True),
         ("chaintool_invalid_sample.json", False),
         ("coinbase_sample.json", True),
+        ("coinbase_additional_metadata_sample.json", True),
         ("coinbase_invalid_sample.json", False),
         ("goplus_sample.json", True),
         ("messari_sample.json", True),


### PR DESCRIPTION
Made a fork from chainmetareader to chainmeta-core and only keeping the core schema/validation information. API server, upload worker will be put into separate repo.

Update the json schema for the artifact validator and allow two new fields:
- `additional_metadata`
-  `deleted`