### PR TITLE
write valid_from, valid_to and additional_metadata columns to db

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
-        pytest -v
+        pytest -v --ignore-glob="**/integration_tests/*"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
   rev: 3.9.2
   hooks:
   - id: flake8
+    args: ["--extend-ignore=W503"]
 - repo: https://github.com/PyCQA/isort
   rev: 5.12.0
   hooks:

--- a/chainmeta/db.py
+++ b/chainmeta/db.py
@@ -100,7 +100,7 @@ def flatten(metadata_list: List[ChainmetaItem]) -> List[ChainmetaRecord]:
             logger.warning("Invalid submitted_on date: %s", metadata.submitted_on)
             continue
 
-        valid_from_: datetime | None = None
+        valid_from_: Optional[datetime] = None
         if "valid_from" in metadata.additional_metadata:
             valid_from_str = metadata.additional_metadata["valid_from"]
             try:
@@ -108,7 +108,7 @@ def flatten(metadata_list: List[ChainmetaItem]) -> List[ChainmetaRecord]:
             except Exception:
                 logger.warning("Invalid valid_from date: %s", valid_from_str)
 
-        valid_to_: datetime | None = None
+        valid_to_: Optional[datetime] = None
         if "valid_to" in metadata.additional_metadata:
             valid_to_str = metadata.additional_metadata["valid_to"]
             try:

--- a/examples/coinbase_artifact_sample.json
+++ b/examples/coinbase_artifact_sample.json
@@ -63,5 +63,22 @@
         "source": "ground_truth",
         "submitted_by": "coinbase",
         "submitted_on": "2022-09-21 00:00:00.000000000"
+    },
+    {
+        "address": "0xd5da8cef79c430d337fdb4d7a5b6646132395a86",
+        "chain": "ethereum_mainnet",
+        "entity": null,
+        "name": null,
+        "categories": [
+            "sanctioned"
+        ],
+        "source": "ground_truth",
+        "submitted_by": "coinbase",
+        "submitted_on": "2022-09-21 00:00:00.000000000",
+        "additional_metadata": {
+            "valid_from": "2022-09-21 00:00:00.000000000",
+            "valid_to": "2024-09-21 00:00:00.000000000",
+            "reason": "https://xyz.com"
+        }
     }
 ]

--- a/tests/integration_tests/test_e2e.py
+++ b/tests/integration_tests/test_e2e.py
@@ -1,0 +1,15 @@
+import pathlib
+
+def test_upload():
+    import chainmeta
+
+    chainmeta.set_connection_string("mysql+pymysql://root:test@127.0.0.1:3306/chainmeta")
+
+    data_folder = pathlib.Path(__file__).parent.resolve().joinpath("../data")
+    resolved_input_file = data_folder.joinpath("coinbase_additional_metadata_sample.json")
+    with open(resolved_input_file) as fp:
+        m = chainmeta.load(fp, artifact_base_path=data_folder)
+        total = chainmeta.upload_chainmeta(m["chainmetadata"]["artifact"])
+        if total == 0:
+            assert False, "make sure the local db is up and running"
+        assert total == 21

--- a/tests/integration_tests/test_e2e.py
+++ b/tests/integration_tests/test_e2e.py
@@ -1,12 +1,30 @@
+# Copyright 2023 The chainmetareader Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pathlib
+
 
 def test_upload():
     import chainmeta
 
-    chainmeta.set_connection_string("mysql+pymysql://root:test@127.0.0.1:3306/chainmeta")
+    chainmeta.set_connection_string(
+        "mysql+pymysql://root:test@127.0.0.1:3306/chainmeta"
+    )
 
     data_folder = pathlib.Path(__file__).parent.resolve().joinpath("../data")
-    resolved_input_file = data_folder.joinpath("coinbase_additional_metadata_sample.json")
+    resolved_input_file = data_folder.joinpath(
+        "coinbase_additional_metadata_sample.json"
+    )
     with open(resolved_input_file) as fp:
         m = chainmeta.load(fp, artifact_base_path=data_folder)
         total = chainmeta.upload_chainmeta(m["chainmetadata"]["artifact"])


### PR DESCRIPTION
In previous changes (https://github.com/microscopexyz/chainmeta-core/commit/6525c699685a9e55db1b2727e035efb91483346e, https://github.com/microscopexyz/chainmeta-core/commit/c187ae76edb3fb16c1d3f82d1a082a4a171143f0), we added 3 new fields to the DB schema:
1. `valid_from`, nullable datetime
2. `valid_to`, nullable datetime
3. `additional_metadata`, nullable JSON, hold category specific info. For example, `sanctioned` category can have a `reason` and the additional_metadata would looks like `{"reason": "http://xyz.com"}`

In previous change https://github.com/microscopexyz/chainmeta-core/commit/16bf5d7792000228bc81a64783d99fe43721f514, we updated the JSON validator for artifact files and allow contributors to include the `valid_from`, `valid_to` and `reason` as part of the `additional_metadata`.

**This change is to get the newly added information from the artifact file and write them to the DB.**